### PR TITLE
Use Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
     default: 'yarn.lock'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
   post-if: 'success()'


### PR DESCRIPTION
Node.js 12 actions are deprecated, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/